### PR TITLE
Support the debuggers envFile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The extension will look for a configuration in launch.json with `"type": "python
  * debugStdLib
  * justMyCode
  * subProcess
+ * envFile
 
 For example,
 ```json
@@ -113,7 +114,8 @@ For example,
             "request": "test",
             "console": "externalTerminal",
             "justMyCode": false,
-            "stopOnEntry": true
+            "stopOnEntry": true,
+            "envFile": "${workspaceFolder}/.env.test",
         }
     ]
 }

--- a/src/pythonTestAdapter.ts
+++ b/src/pythonTestAdapter.ts
@@ -33,6 +33,7 @@ interface IPythonTestDebugConfig {
     debugStdLib?: boolean;
     justMyCode?: boolean;
     subProcess?: boolean;
+    envFile?: string;
 }
 
 export class PythonTestAdapter implements TestAdapter {
@@ -271,6 +272,7 @@ export class PythonTestAdapter implements TestAdapter {
                         debugStdLib: cfg.debugStdLib,
                         justMyCode: cfg.justMyCode,
                         subProcess: cfg.subProcess,
+                        envFile: cfg.envFile,
                     })),
                 emptyJsonConfiguration
             );


### PR DESCRIPTION
This addresses #204.

### Summary

This PR modifies the debug configuration to allow the `envFile` property. This will modify the environment variables loaded to be:

1. System defaults
2. Workspace `envFile` file if it exists
3. `env` **and** `envFile` debugger settings

### Scenario

This is needed for my current configuration without having to maintain both a `.env.test` for the CI and a `launch.json` file. Consider this example:

* A user has defined a default `envFile` in their workspace settings (settings.json)

```
    "python.envFile": "${workspaceFolder}/.env.defaults",
```

* However, they want to override those defaults in a test environment (launch.json):

```
    {
      "name": "Debug Unit Tests",
      "type": "python",
      "request": "test",
      "envFile": "${workspaceFolder}/.env.test",
    }
```

### Summary of Changes

* Simply, the `envFile` key is added to the `IPythonTestDebugConfig` interface and `detectDebugConfiguration`.
* No tests were added